### PR TITLE
Allow setting ulimits via attributes

### DIFF
--- a/attributes/node.rb
+++ b/attributes/node.rb
@@ -77,3 +77,11 @@ default['jenkins']['node']['ssh_port'] = 22
 default['jenkins']['node']['ssh_user'] = default['jenkins']['node']['user']
 default['jenkins']['node']['ssh_pass'] = nil
 default['jenkins']['node']['ssh_private_key'] = nil
+
+
+# The limits for the Java process running the node.
+# Example to configure the maximum number of open file descriptors:
+#
+#   node.set['jenkins']['node']['ulimits'] = { 'n' => 8192 }
+#
+default['jenkins']['node']['ulimits'] = nil

--- a/templates/default/sv-jenkins-slave-run.erb
+++ b/templates/default/sv-jenkins-slave-run.erb
@@ -1,6 +1,10 @@
 #!/bin/sh
 exec 2>&1
 cd <%= node['jenkins']['node']['home'] %>
+<% limits = node['jenkins']['node']['ulimits'] %>
+<% if limits && !limits.empty? %>
+ulimit <% limits.each { |option, value| %>-<%= option %> <%= value %> <% } %>
+<% end %>
 exec chpst -u <%= node['jenkins']['node']['user'] %><%= ":#{node['jenkins']['node']['chpst_groups'].join(':')}" if node['jenkins']['node']['chpst_groups'] %> \
   env HOME=<%= node['jenkins']['node']['home'] %> \
   USER=<%= node['jenkins']['node']['user'] %> \


### PR DESCRIPTION
There is currently an ongoing issue with java running out of file descriptors. This change allows settings ulimits on a node level.

The patch is based on https://github.com/chef-cookbooks/jenkins/commit/e08649d3c124959273f9af9b7e5a1c48d7614605

PD-17930